### PR TITLE
Add the Snow validator to the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,15 @@ This project provides conformance tests to the [JSON Schema Specification]. All 
 
 ## Test Results
 
-The following table shows the number of failures occurred while testing popular JSON validators written in JVM languages as of 2020-05-12.
+The following table shows the number of failures occurred while testing popular JSON validators written in JVM languages as of 2020-10-25.
 
-| Software | Version | Draft-07 | Draft-06 | Draft-04 |
-| --- | --- | ---: | ---: | ---: |
-| [everit-org/json-schema] | 1.12.1 | 32 | 19 | 16 |
-| [java-json-tools/json-schema-validator] | 2.2.13 | n/a | n/a | 22 |
-| [Justify] | 3.0.0-RC2 | 0 | 0 | 0 |
-| [networknt/json-schema-validator] | 1.0.39 | 55 | 37 | 19 |
+| Software | Version | Draft 2019-09 | Draft-07 | Draft-06 | Draft-04 |
+| --- | --- | ---: | ---: | ---: | ---: |
+| [everit-org/json-schema] | 1.12.1 | n/a | 32 | 19 | 16 |
+| [java-json-tools/json-schema-validator] | 2.2.13 | n/a | n/a | n/a | 22 |
+| [Justify] | 3.0.0-RC2 | n/a | 0 | 0 | 0 |
+| [networknt/json-schema-validator] | 1.0.39 | n/a | 55 | 37 | 19 |
+| [ssilverman/snowy-json] | 0.15.0 | 2 | 2 | 2 | n/a |
 
 Note that _n/a_ in the table means that the software does not support the version of the specification.
 
@@ -41,3 +42,4 @@ Copyright &copy; 2019-2020 leadpony. This software is licensed under [Apache Lic
 [java-json-tools/json-schema-validator]: https://github.com/java-json-tools/json-schema-validator
 [Justify]: https://github.com/leadpony/justify
 [networknt/json-schema-validator]: https://github.com/networknt/json-schema-validator
+[ssilverman/snowy-json]: https://github.com/ssilverman/snowy-json

--- a/jsct-snow-validator/pom.xml
+++ b/jsct-snow-validator/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.leadpony.jsct</groupId>
+        <artifactId>jsct</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jsct-snow-validator</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Snow Validator Test</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jsct-base</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.qindesign</groupId>
+            <artifactId>snowy-json</artifactId>
+            <version>0.15.0-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/jsct-snow-validator/src/test/java/org/leadpony/jsonschema/test/snow/AbstractConformanceTest.java
+++ b/jsct-snow-validator/src/test/java/org/leadpony/jsonschema/test/snow/AbstractConformanceTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2019 the original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.leadpony.jsonschema.test.snow;
+
+import com.google.gson.JsonElement;
+import com.qindesign.json.schema.Annotation;
+import com.qindesign.json.schema.Error;
+import com.qindesign.json.schema.JSON;
+import com.qindesign.json.schema.JSONPath;
+import com.qindesign.json.schema.MalformedSchemaException;
+import com.qindesign.json.schema.Option;
+import com.qindesign.json.schema.Options;
+import com.qindesign.json.schema.Specification;
+import com.qindesign.json.schema.Validator;
+import org.leadpony.jsonschema.test.base.ConformanceTest;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.net.URL;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * @author Shawn Silverman (shawn@pobox.com)
+ */
+abstract class AbstractConformanceTest extends ConformanceTest {
+    private static Map<com.qindesign.net.URI, JsonElement> knownIDs;
+    private static Map<com.qindesign.net.URI, URL> knownURLs;
+    private static Options options;
+
+    private static final AtomicInteger testNum = new AtomicInteger(0);
+
+    static void setUp(Specification spec) throws IOException {
+        knownIDs = Collections.emptyMap();
+        knownURLs = new HashMap<>();
+        knownURLs.put(com.qindesign.net.URI.parseUnchecked("http://localhost:1234"),
+                      new URL("http://localhost:1234/"));
+
+        options = new Options();
+        options.set(Option.FORMAT, true);
+        options.set(Option.CONTENT, true);
+        options.set(Option.DEFAULT_SPECIFICATION, spec);
+    }
+
+    @Override
+    protected boolean validate(String schemaJson, String dataJson) {
+        JsonElement testSchema = JSON.parse(new StringReader(schemaJson));
+        JsonElement testData = JSON.parse(new StringReader(dataJson));
+        try {
+            // Use a URN for the base URI for this test because we don't have
+            // access to the file URI here
+            Validator validator = new Validator(
+                testSchema,
+                com.qindesign.net.URI.parseUnchecked("urn:jsct-test:" + testNum.incrementAndGet()),
+                knownIDs, knownURLs, options);
+            Map<JSONPath, Map<String, Map<JSONPath, Annotation<?>>>> annotations = new HashMap<>();
+            Map<JSONPath, Map<JSONPath, Error<?>>> errors = new HashMap<>();
+            return validator.validate(testData, annotations, errors);
+        } catch (MalformedSchemaException ex) {
+            throw new IllegalArgumentException(ex);
+        }
+    }
+}

--- a/jsct-snow-validator/src/test/java/org/leadpony/jsonschema/test/snow/Draft06Test.java
+++ b/jsct-snow-validator/src/test/java/org/leadpony/jsonschema/test/snow/Draft06Test.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 the original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.leadpony.jsonschema.test.snow;
+
+import com.qindesign.json.schema.Specification;
+import org.junit.jupiter.api.BeforeAll;
+import org.leadpony.jsonschema.test.base.Fixture;
+
+import java.io.IOException;
+import java.util.stream.Stream;
+
+/**
+ * @author Shawn Silverman (shawn@pobox.com)
+ */
+public class Draft06Test extends AbstractConformanceTest {
+    public static Stream<Fixture> fixtures() throws IOException {
+        return fromSpec("draft6");
+    }
+
+    @BeforeAll
+    public static void setUpOnce() throws IOException {
+        setUp(Specification.DRAFT_06);
+    }
+}

--- a/jsct-snow-validator/src/test/java/org/leadpony/jsonschema/test/snow/Draft07Test.java
+++ b/jsct-snow-validator/src/test/java/org/leadpony/jsonschema/test/snow/Draft07Test.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 the original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.leadpony.jsonschema.test.snow;
+
+import com.qindesign.json.schema.Specification;
+import org.junit.jupiter.api.BeforeAll;
+import org.leadpony.jsonschema.test.base.Fixture;
+
+import java.io.IOException;
+import java.util.stream.Stream;
+
+/**
+ * @author Shawn Silverman (shawn@pobox.com)
+ */
+public class Draft07Test extends AbstractConformanceTest {
+    public static Stream<Fixture> fixtures() throws IOException {
+        return fromSpec("draft7");
+    }
+
+    @BeforeAll
+    public static void setUpOnce() throws IOException {
+        setUp(Specification.DRAFT_07);
+    }
+}

--- a/jsct-snow-validator/src/test/java/org/leadpony/jsonschema/test/snow/Draft2019_09Test.java
+++ b/jsct-snow-validator/src/test/java/org/leadpony/jsonschema/test/snow/Draft2019_09Test.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 the original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.leadpony.jsonschema.test.snow;
+
+import com.qindesign.json.schema.Specification;
+import org.junit.jupiter.api.BeforeAll;
+import org.leadpony.jsonschema.test.base.Fixture;
+
+import java.io.IOException;
+import java.util.stream.Stream;
+
+/**
+ * @author Shawn Silverman (shawn@pobox.com)
+ */
+public class Draft2019_09Test extends AbstractConformanceTest {
+    public static Stream<Fixture> fixtures() throws IOException {
+        return fromSpec("draft2019-09");
+    }
+
+    @BeforeAll
+    public static void setUpOnce() throws IOException {
+        setUp(Specification.DRAFT_2019_09);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
         <module>jsct-justify</module>
         <module>jsct-medeia-validator</module>
         <module>jsct-networknt-validator</module>
+        <module>jsct-snow-validator</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
Note that there are still two failing tests per draft, but that's because the ecmascript-regex.json tests assume an earlier version of the ECMA-262 regex spec. I based mine on 11. Also, the latest tests fix this problem; that submodule should probably be updated.

While I was there, I also added the Medeia validator results to the README.